### PR TITLE
Update to github downloads and 0.12.4

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,71 +8,55 @@ platforms:
   driver_config:
     customize:
       memory: 1024
-    box: opscode-centos-6.6
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
+    box: bento/centos-6.9
     hostname: wkhtmltopdf-centos-6
 - name: centos7
   driver_config:
     customize:
       memory: 1024
-    box: opscode-centos-7.0
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box
+    box: bento/centos-7.3
     hostname: wkhtmltopdf-centos-7
-- name: debian7
+- name: debian9
   driver_config:
     customize:
       memory: 1024
-    box: opscode-debian-7.7
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.7_chef-provisionerless.box
-    hostname: wkhtmltopdf-debian-7
-- name: fedora18
+    box: bento/debian-9.0
+    hostname: wkhtmltopdf-debian-9
+- name: fedora24
   driver_config:
     customize:
       memory: 1024
-    box: opscode-fedora-18
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-18_chef-provisionerless.box
-    hostname: wkhtmltopdf-fedora-18
-- name: fedora19
+    box: bento/fedora-24
+    hostname: wkhtmltopdf-fedora-24
+- name: fedora25
   driver_config:
     customize:
       memory: 1024
-    box: opscode-fedora-19
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-19_chef-provisionerless.box
-    hostname: wkhtmltopdf-fedora-19
-- name: fedora20
-  driver_config:
-    customize:
-      memory: 1024
-    box: opscode-fedora-20
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box
-    hostname: wkhtmltopdf-fedora-20
+    box: bento/fedora-25
+    hostname: wkhtmltopdf-fedora-25
 - name: freebsd10
   driver_config:
     customize:
       memory: 1024
-    box: opscode-freebsd-10.3
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-10.1_chef-provisionerless.box
+    box: bento/freebsd-10.3
     hostname: wkhtmltopdf-freebsd-10
 - name: freebsd11
   driver_config:
     customize:
       memory: 1024
-    box: opscode-freebsd-11.0
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-11.0_chef-provisionerless.box
+    box: bento/freebsd-11.0
     hostname: wkhtmltopdf-freebsd-11
 - name: ubuntu1204
   driver_config:
     customize:
       memory: 1024
-    box: opscode-ubuntu-12.04
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+    box: bento/ubuntu-12.04
     hostname: wkhtmltopdf-ubuntu-1204
 - name: ubuntu1404
   driver_config:
     customize:
       memory: 1024
-    box: opscode-ubuntu-14.04
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+    box: bento/ubuntu-14.04
     hostname: wkhtmltopdf-ubuntu-1404
 
 suites:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,13 +4,6 @@ driver_config:
   require_chef_omnibus: '11.16.4'
 
 platforms:
-- name: centos5
-  driver_config:
-    customize:
-      memory: 1024
-    box: opscode-centos-5.11
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.11_chef-provisionerless.box
-    hostname: wkhtmltopdf-centos-5
 - name: centos6
   driver_config:
     customize:
@@ -95,5 +88,3 @@ suites:
       install_method: source
       lib_dir: /usr/local/lib
       build_cache_path: /var/cache/chef/wkhtmltopdf
-  excludes:
-  - centos5 # Python < 2.5

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -85,6 +85,9 @@ platforms:
 suites:
 - name: default
   run_list: ["recipe[wkhtmltopdf]"]
+  attributes:
+    wkhtmltopdf:
+      lib_dir: /usr/local/lib
 - name: source
   run_list: ["recipe[wkhtmltopdf]"]
   attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -53,20 +53,20 @@ platforms:
     box: opscode-fedora-20
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box
     hostname: wkhtmltopdf-fedora-20
-- name: freebsd9
-  driver_config:
-    customize:
-      memory: 1024
-    box: opscode-freebsd-9.2
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-9.2_chef-provisionerless.box
-    hostname: wkhtmltopdf-freebsd-9
 - name: freebsd10
   driver_config:
     customize:
       memory: 1024
-    box: opscode-freebsd-10.1
+    box: opscode-freebsd-10.3
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-10.1_chef-provisionerless.box
     hostname: wkhtmltopdf-freebsd-10
+- name: freebsd11
+  driver_config:
+    customize:
+      memory: 1024
+    box: opscode-freebsd-11.0
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-11.0_chef-provisionerless.box
+    hostname: wkhtmltopdf-freebsd-11
 - name: ubuntu1204
   driver_config:
     customize:

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,10 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+# Use Chef 11 for development so set dependencies to old versions:
+cookbook 'apt', '< 4.0.0'
+cookbook 'ark', '< 2.0.0'
+cookbook 'freebsd', '< 1.0.0'
+cookbook 'ohai', '< 4.0.0'
+cookbook 'build-essential', '< 4.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gem 'rake'
 
+# Lock to Chef 11.16.4 for testing
+gem 'chef', '11.16.4'
+gem 'ffi-yajl', '1.2.0' # Before ffi-yajl/json_gem was deprecated
+
 group :test, :integration do
   gem 'berkshelf', '~> 4.0.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,19 +3,19 @@ source 'https://rubygems.org'
 gem 'rake'
 
 group :test, :integration do
-  gem 'berkshelf', '~> 2.0.14'
+  gem 'berkshelf', '~> 4.0.1'
 end
 
 group :test do
   gem 'chefspec', '~> 4.0'
-  gem 'foodcritic', '~> 3.0.3'
-  gem 'rubocop', '~> 0.23'
+  gem 'foodcritic'
+  gem 'rubocop'
 end
 
 group :integration do
-  gem 'busser-serverspec', '~> 0.2.6'
-  gem 'kitchen-vagrant', '~> 0.14'
-  gem 'test-kitchen', '~> 1.1'
+  gem 'busser-serverspec', '~> 0.5'
+  gem 'kitchen-vagrant', '~> 1.1'
+  gem 'test-kitchen', '~> 1.16'
 end
 
 # group :development do

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Cookbook Compatibility:
 * Ubuntu 12.04
 * Ubuntu 14.04
 
+### Chef
+
+* Chef 11+
+
 ### Cookbooks
 
 [Opscode Cookbooks](https://github.com/opscode-cookbooks/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# chef-wkhtmltopdf [![Build Status](https://secure.travis-ci.org/bflad/chef-wkhtmltopdf.png?branch=master)](http://travis-ci.org/bflad/chef-wkhtmltopdf)
+# chef-wkhtmltopdf
 
 ## Description
 
@@ -8,6 +8,7 @@ Cookbook Compatibility:
  * chef-wkhtmltopdf 0.1.0: wkhtmltopdf 0.11.0_rc1
  * chef-wkhtmltopdf 0.2.0: wkhtmltopdf 0.12.0
  * chef-wkhtmltopdf 0.3.0: wkhtmltopdf 0.12.1
+ * chef-wkhtmltopdf 0.4.0: wkhtmltopdf 0.12.1 to 0.12.4
 
 ## Requirements
 
@@ -28,21 +29,21 @@ Cookbook Compatibility:
 
 These attributes are under the `node['wkhtmltopdf']` namespace.
 
-Attribute | Description | Type | Default
-----------|-------------|------|--------
-archive | wkhtmltopdf archive name | String | `wkhtmltox-#{node['wkhtmltopdf']['version']}_#{node['wkhtmltopdf']['platform']}-#{node['wkhtmltopdf']['architecture']}.#{node['wkhtmltopdf']['suffix']}`
-dependency_packages | Packages that contain wkhtmltopdf dependencies | String | (auto-detected, see attributes/default.rb)
-install_dir | directory to install with source | String | /usr/local/bin
-lib_dir | directory to install libraries | String | ''
-mirror_url | URL for wkhtmltopdf | String | (auto-detected, see attributes/default.rb)
-suffix | wkhtmltopdf suffix | String | (auto-detected, see attributes/default.rb)
-platform | wkhtmltopdf platform | String | (auto-detected, see attributes/default.rb)
-architecture | wkhtmltopdf architecture | String | (auto-detected, see attributes/default.rb)
-version | wkhtmltopdf version to install | String | 0.12.1
+Attribute      | Description                      | Type   | Default
+---------------|----------------------------------|--------|--------
+`archive`      | wkhtmltopdf archive name         | String | `wkhtmltox-#{node['wkhtmltopdf']['version']}_#{node['wkhtmltopdf']['platform']}-#{node['wkhtmltopdf']['architecture']}.#{node['wkhtmltopdf']['suffix']}`
+`dependency_packages` | Packages that contain wkhtmltopdf dependencies | String | (auto-detected, see attributes/default.rb)
+`install_dir`  | directory to install with source | String | `/usr/local/bin`
+`lib_dir`      | directory to install libraries   | String | `''`
+`mirror_url`   | URL for wkhtmltopdf              | String | (auto-detected, see attributes/default.rb)
+`suffix`       | wkhtmltopdf suffix               | String | (auto-detected, see attributes/default.rb)
+`platform`     | wkhtmltopdf platform             | String | (auto-detected, see attributes/default.rb)
+`architecture` | wkhtmltopdf architecture         | String | (auto-detected, see attributes/default.rb)
+`version`      | wkhtmltopdf version to install   | String | 0.12.4
 
 ## Recipes
 
-* `recipe[wkhtmltopdf]` Installs wkhtmltoimage and wkhtmltopdf
+* `recipe[wkhtmltopdf]` Installs wkhtmltoimage and wkhtmltopdf using install method from `node['wkhtmltopdf']['install_method']`
 * `recipe[wkhtmltopdf::binary]` Installs wkhtmltoimage and wkhtmltopdf static binaries
 * `recipe[wkhtmltopdf::source]` Installs wkhtmltoimage and wkhtmltopdf from source
 
@@ -52,28 +53,35 @@ version | wkhtmltopdf version to install | String | 0.12.1
 
 ## Testing and Development
 
-Here's how you can quickly get testing or developing against the cookbook thanks to [Vagrant](http://vagrantup.com/) and [Berkshelf](http://berkshelf.com/).
+Here's how you can quickly get testing or developing against the cookbook thanks to [chefspec](https://chefspec.github.io/chefspec/) and [test-kitchen](http://kitchen.ci/).
 
-    vagrant plugin install vagrant-berkshelf
-    vagrant plugin install vagrant-cachier
-    vagrant plugin install vagrant-omnibus
-    git clone git://github.com/bflad/chef-wkhtmltopdf.git
+    git clone git://github.com/Fatsoma/chef-wkhtmltopdf.git
     cd chef-wkhtmltopdf
-    vagrant up BOX # BOX being centos5, centos6, debian7, fedora18, fedora19, fedora20, freebsd9, ubuntu1204, ubuntu1210, ubuntu1304, or ubuntu1310
 
-You can then SSH into the running VM using the `vagrant ssh BOX` command.
+Run chefspec with:
 
-The VM can easily be stopped and deleted with the `vagrant destroy` command. Please see the official [Vagrant documentation](http://docs.vagrantup.com/v2/cli/index.html) for a more in depth explanation of available commands.
+    rspec
+
+Find kitchen suites (from `.kitchen.yml`) and run them (specifying by `NAME`):
+
+    kitchen list
+    kitchen test NAME
+
+You can bring up a VM to login to with (specifying `NAME`):
+
+    kitchen test -d never NAME
+    kitchen login NAME
+    kitchen destroy NAME
 
 ## Contributing
 
-Please use standard Github issues/pull requests and if possible, in combination with testing on the Vagrant boxes.
+Please use standard Github issues/pull requests and if possible, in combination with testing using chefspec and test-kitchen.
 
 ## Maintainers
 
-* Brian Flad (<bflad417@gmail.com>)
+* Bill Ruddock (bill.ruddock@fatsoma.com)
+* Brian Flad (bflad417@gmail.com)
 
 ## License
 
 Please see licensing information in: [LICENSE](LICENSE)
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,7 @@ when 'debian'
 
 when 'rhel', 'fedora'
   jpeg_package = 'libjpeg'
+  archive_packages = []
   default['wkhtmltopdf']['suffix'] = 'rpm'
   if node['platform_family'] == 'fedora'
     jpeg_package = 'libjpeg-turbo'
@@ -76,8 +77,9 @@ when 'rhel', 'fedora'
     default['wkhtmltopdf']['platform'] = 'linux-generic'
     default['wkhtmltopdf']['suffix'] = 'tar.xz'
     default['wkhtmltopdf']['extracted_name'] = 'wkhtmltox'
+    archive_packages = %w(xz)
   end
-  default['wkhtmltopdf']['dependency_packages'] = %W(fontconfig freetype libpng zlib #{jpeg_package} openssl libX11 libXext libXrender libstdc++ glibc)
+  default['wkhtmltopdf']['dependency_packages'] = %W(fontconfig freetype libpng zlib #{jpeg_package} openssl libX11 libXext libXrender libstdc++ glibc) + archive_packages
   default['wkhtmltopdf']['architecture'] =
     if node['kernel']['machine'] == 'x86_64'
       'amd64'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default['wkhtmltopdf']['version']        = '0.12.1'
+default['wkhtmltopdf']['version']        = '0.12.4'
 default['wkhtmltopdf']['install_method'] = 'binary'
 default['wkhtmltopdf']['install_dir']    = '/usr/local/bin'
 default['wkhtmltopdf']['lib_dir']        = ''
@@ -41,6 +41,11 @@ when 'debian'
       default['wkhtmltopdf']['platform'] = 'linux-precise'
     end
   end
+  if Chef::VersionConstraint.new('>= 0.12.3').include?(node['wkhtmltopdf']['version'])
+    default['wkhtmltopdf']['platform'] = 'linux-generic'
+    default['wkhtmltopdf']['suffix'] = 'tar.xz'
+    default['wkhtmltopdf']['extracted_name'] = 'wkhtmltox'
+  end
   default['wkhtmltopdf']['dependency_packages'] = %W(fontconfig libfontconfig1 libfreetype6 libpng12-0 zlib1g #{jpeg_package} libssl1.0.0 libx11-6 libxext6 libxrender1 libstdc++6 libc6)
   default['wkhtmltopdf']['architecture'] =
     if node['kernel']['machine'] == 'x86_64'
@@ -66,6 +71,11 @@ when 'rhel', 'fedora'
     default['wkhtmltopdf']['platform'] = 'linux-centos6'
   else
     default['wkhtmltopdf']['platform'] = 'linux-centos5'
+  end
+  if Chef::VersionConstraint.new('>= 0.12.3').include?(node['wkhtmltopdf']['version'])
+    default['wkhtmltopdf']['platform'] = 'linux-generic'
+    default['wkhtmltopdf']['suffix'] = 'tar.xz'
+    default['wkhtmltopdf']['extracted_name'] = 'wkhtmltox'
   end
   default['wkhtmltopdf']['dependency_packages'] = %W(fontconfig freetype libpng zlib #{jpeg_package} openssl libX11 libXext libXrender libstdc++ glibc)
   default['wkhtmltopdf']['architecture'] =

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,11 +20,12 @@ when 'windows'
   default['wkhtmltopdf']['suffix'] = 'exe'
   default['wkhtmltopdf']['platform'] = 'mingw-w64-cross'
   # or default['wkhtmltopdf']['platform'] = 'msvc2013'
-  if node['kernel']['machine'] == 'x86_64'
-    default['wkhtmltopdf']['architecture'] = 'win64'
-  else
-    default['wkhtmltopdf']['architecture'] = 'win32'
-  end
+  default['wkhtmltopdf']['architecture'] =
+    if node['kernel']['machine'] == 'x86_64'
+      'win64'
+    else
+      'win32'
+    end
 
 when 'debian'
   jpeg_package = 'libjpeg8'
@@ -41,11 +42,12 @@ when 'debian'
     end
   end
   default['wkhtmltopdf']['dependency_packages'] = %W(fontconfig libfontconfig1 libfreetype6 libpng12-0 zlib1g #{jpeg_package} libssl1.0.0 libx11-6 libxext6 libxrender1 libstdc++6 libc6)
-  if node['kernel']['machine'] == 'x86_64'
-    default['wkhtmltopdf']['architecture'] = 'amd64'
-  else
-    default['wkhtmltopdf']['architecture'] = 'i386'
-  end
+  default['wkhtmltopdf']['architecture'] =
+    if node['kernel']['machine'] == 'x86_64'
+      'amd64'
+    else
+      'i386'
+    end
 
 when 'rhel', 'fedora'
   jpeg_package = 'libjpeg'
@@ -66,11 +68,12 @@ when 'rhel', 'fedora'
     default['wkhtmltopdf']['platform'] = 'linux-centos5'
   end
   default['wkhtmltopdf']['dependency_packages'] = %W(fontconfig freetype libpng zlib #{jpeg_package} openssl libX11 libXext libXrender libstdc++ glibc)
-  if node['kernel']['machine'] == 'x86_64'
-    default['wkhtmltopdf']['architecture'] = 'amd64'
-  else
-    default['wkhtmltopdf']['architecture'] = 'i386'
-  end
+  default['wkhtmltopdf']['architecture'] =
+    if node['kernel']['machine'] == 'x86_64'
+      'amd64'
+    else
+      'i386'
+    end
 
 when 'freebsd'
   default['wkhtmltopdf']['dependency_packages'] = %w(fontconfig freetype2 jpeg png libiconv libX11 libXext libXrender)
@@ -108,5 +111,4 @@ else
   default['wkhtmltopdf']['archive'] = "wkhtmltox-#{node['wkhtmltopdf']['version']}_#{node['wkhtmltopdf']['platform']}-#{node['wkhtmltopdf']['architecture']}.#{node['wkhtmltopdf']['suffix']}"
 end
 
-parent_folder = node['wkhtmltopdf']['version'].split('.').take(2).join('.')
-default['wkhtmltopdf']['mirror_url'] = "http://download.gna.org/wkhtmltopdf/#{parent_folder}/#{node['wkhtmltopdf']['version']}/#{node['wkhtmltopdf']['archive']}"
+default['wkhtmltopdf']['mirror_url'] = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf']['version']}/#{node['wkhtmltopdf']['archive']}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,3 +19,4 @@ supports 'ubuntu'
 
 depends 'apt'
 depends 'freebsd'
+depends 'ark'

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,3 +20,8 @@ supports 'ubuntu'
 depends 'apt'
 depends 'freebsd'
 depends 'ark'
+
+source_url 'https://github.com/Fatsoma/chef-wkhtmltopdf' if respond_to?(:source_url)
+issues_url 'https://github.com/Fatsoma/chef-wkhtmltopdf/issues' if respond_to?(:issues_url)
+
+chef_version '>= 11.0' if respond_to?(:chef_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name 'wkhtmltopdf'
-maintainer 'Brian Flad'
-maintainer_email 'bflad417@gmail.com'
+maintainer 'Bill Ruddock'
+maintainer_email 'bill.ruddock@fatsoma.com'
 license 'Apache 2.0'
 description 'Installs wkhtmltoimage and wkhtmltopdf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.0'
+version '0.4.0'
 
 recipe 'wkhtmltopdf', 'Installs wkhtmltoimage and wkhtmltopdf'
 recipe 'wkhtmltopdf::binary', 'Installs wkhtmltoimage and wkhtmltopdf binaries'

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -1,38 +1,61 @@
 cache_dir = Chef::Config[:file_cache_path]
 download_dest = File.join(cache_dir, node['wkhtmltopdf']['archive'])
 
-remote_file download_dest do
-  source node['wkhtmltopdf']['mirror_url']
-  mode '0644'
-  action :create_if_missing
-  not_if { node['platform_family'] == 'freebsd' }
-end
+if node['wkhtmltopdf']['platform'] == 'linux-generic'
+  wkhtmltopdf_version = Chef::Version.new(node['wkhtmltopdf']['version'])
 
-case node['platform_family']
-when 'mac_os_x', 'mac_os_x_server'
-  execute 'install_wkhtmltox' do
-    command "installer -pkg #{download_dest} -target /"
+  ark 'wkhtmltopdf' do
+    url node['wkhtmltopdf']['mirror_url']
+    version node['wkhtmltopdf']['version']
   end
-when 'windows'
-  execute 'install_wkhtmltox' do
-    command download_dest
-  end
-when 'debian'
-  dpkg_package 'wkhtmltox' do
-    source download_dest
-  end
-when 'rhel', 'fedora'
-  rpm_package 'wkhtmltox' do
-    source download_dest
-  end
-when 'freebsd'
-  # Force support pkgng as it seems to check before freebsd::pkgng is run
-  Chef::Resource::FreebsdPackage.class_eval do
-    def supports_pkgng?
-      true
+  unless node['wkhtmltopdf']['lib_dir'].empty?
+    link File.join(node['wkhtmltopdf']['lib_dir'], "libwkhtmltox.so.#{node['wkhtmltopdf']['version']}") do
+      to File.join(node['ark']['prefix_root'], 'wkhtmltopdf', 'lib', "libwkhtmltox.so.#{node['wkhtmltopdf']['version']}")
+    end
+    link File.join(node['wkhtmltopdf']['lib_dir'], "libwkhtmltox.so.#{wkhtmltopdf_version.major}.#{wkhtmltopdf_version.minor}") do
+      to File.join(node['wkhtmltopdf']['lib_dir'], "libwkhtmltox.so.#{node['wkhtmltopdf']['version']}")
+    end
+    link File.join(node['wkhtmltopdf']['lib_dir'], "libwkhtmltox.so.#{wkhtmltopdf_version.major}") do
+      to File.join(node['wkhtmltopdf']['lib_dir'], "libwkhtmltox.so.#{node['wkhtmltopdf']['version']}")
+    end
+    link File.join(node['wkhtmltopdf']['lib_dir'], 'libwkhtmltox.so') do
+      to File.join(node['wkhtmltopdf']['lib_dir'], "libwkhtmltox.so.#{node['wkhtmltopdf']['version']}")
     end
   end
-  package 'wkhtmltopdf' do
-    version node['wkhtmltopdf']['version']
+else
+  remote_file download_dest do
+    source node['wkhtmltopdf']['mirror_url']
+    mode '0644'
+    action :create_if_missing
+    not_if { node['platform_family'] == 'freebsd' }
+  end
+
+  case node['platform_family']
+  when 'mac_os_x', 'mac_os_x_server'
+    execute 'install_wkhtmltox' do
+      command "installer -pkg #{download_dest} -target /"
+    end
+  when 'windows'
+    execute 'install_wkhtmltox' do
+      command download_dest
+    end
+  when 'debian'
+    dpkg_package 'wkhtmltox' do
+      source download_dest
+    end
+  when 'rhel', 'fedora'
+    rpm_package 'wkhtmltox' do
+      source download_dest
+    end
+  when 'freebsd'
+    # Force support pkgng as it seems to check before freebsd::pkgng is run
+    Chef::Resource::FreebsdPackage.class_eval do
+      def supports_pkgng?
+        true
+      end
+    end
+    package 'wkhtmltopdf' do
+      version node['wkhtmltopdf']['version']
+    end
   end
 end

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -8,6 +8,13 @@ if node['wkhtmltopdf']['platform'] == 'linux-generic'
     url node['wkhtmltopdf']['mirror_url']
     version node['wkhtmltopdf']['version']
   end
+
+  %w(wkhtmltopdf wkhtmltoimage).each do |binary_name|
+    link File.join(node['wkhtmltopdf']['install_dir'], binary_name) do
+      to File.join(node['ark']['prefix_root'], 'wkhtmltopdf', 'bin', binary_name)
+    end
+  end
+
   unless node['wkhtmltopdf']['lib_dir'].empty?
     link File.join(node['wkhtmltopdf']['lib_dir'], "libwkhtmltox.so.#{node['wkhtmltopdf']['version']}") do
       to File.join(node['ark']['prefix_root'], 'wkhtmltopdf', 'lib', "libwkhtmltox.so.#{node['wkhtmltopdf']['version']}")

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -90,4 +90,8 @@ unless node['wkhtmltopdf']['lib_dir'].empty?
   link "#{node['wkhtmltopdf']['lib_dir']}/libwkhtmltox.so.#{wkhtmltopdf_version.major}" do
     to "#{node['wkhtmltopdf']['lib_dir']}/libwkhtmltox.so.#{node['wkhtmltopdf']['version']}"
   end
+
+  link "#{node['wkhtmltopdf']['lib_dir']}/libwkhtmltox.so" do
+    to "#{node['wkhtmltopdf']['lib_dir']}/libwkhtmltox.so.#{node['wkhtmltopdf']['version']}"
+  end
 end

--- a/spec/binary_spec.rb
+++ b/spec/binary_spec.rb
@@ -1,55 +1,104 @@
 require 'spec_helper'
 
 describe 'wkhtmltopdf::binary' do
-  cached(:chef_run) do
-    ChefSpec::SoloRunner.new.converge(described_recipe)
-  end
+  context 'with linux-generic package' do
+    let(:version) { '0.12.4' } # any version >= 0.12.3
+    let(:archive) { "wkhtmltox-#{version}_#{platform}-#{architecture}.#{suffix}" }
+    let(:mirror_url) { "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{version}/#{archive}" }
 
-  let(:cache_dir) { Chef::Config[:file_cache_path] }
-  let(:version) { '0.12.1' }
-  let(:archive) { "wkhtmltox-#{version}_#{platform}-#{architecture}.#{suffix}" }
-  let(:download_dest) { File.join(cache_dir, archive) }
-
-  context 'for ubuntu' do
-    let(:platform) { 'linux-precise' }
+    let(:platform) { 'linux-generic' }
     let(:architecture) { 'amd64' }
-    let(:suffix) { 'deb' }
+    let(:suffix) { 'tar.xz' }
 
-    it { expect(chef_run).to create_remote_file_if_missing(download_dest) }
+    let(:lib_dir) { '/usr/local/lib' }
+    let(:home_dir) { '/usr/local/wkhtmltopdf' }
 
-    it do
-      expect(chef_run).to install_dpkg_package('wkhtmltox')
-        .with_source(download_dest)
-    end
-  end
-
-  context 'for centos' do
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5')
-        .converge(described_recipe)
-    end
-
-    let(:platform) { 'linux-centos6' }
-    let(:architecture) { 'amd64' }
-    let(:suffix) { 'rpm' }
-
-    it { expect(chef_run).to create_remote_file_if_missing(download_dest) }
-
-    it do
-      expect(chef_run).to install_rpm_package('wkhtmltox')
-        .with_source(download_dest)
-    end
-  end
-
-  context 'for freebsd' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'freebsd', version: '9.2')
-        .converge(described_recipe)
+      ChefSpec::SoloRunner.new do |node|
+        node.set['wkhtmltopdf']['version'] = version
+        node.set['wkhtmltopdf']['lib_dir'] = lib_dir
+      end.converge(described_recipe)
     end
 
     it do
-      expect(chef_run).to install_package('wkhtmltopdf')
+      expect(chef_run).to install_ark('wkhtmltopdf')
+        .with_url(mirror_url)
         .with_version(version)
+    end
+
+    it do
+      expect(chef_run).to create_link("#{lib_dir}/libwkhtmltox.so.#{version}")
+        .with_to("#{home_dir}/lib/libwkhtmltox.so.#{version}")
+    end
+    it do
+      expect(chef_run).to create_link("#{lib_dir}/libwkhtmltox.so.0.12")
+        .with_to("#{lib_dir}/libwkhtmltox.so.#{version}")
+    end
+    it do
+      expect(chef_run).to create_link("#{lib_dir}/libwkhtmltox.so.0")
+        .with_to("#{lib_dir}/libwkhtmltox.so.#{version}")
+    end
+    it do
+      expect(chef_run).to create_link("#{lib_dir}/libwkhtmltox.so")
+        .with_to("#{lib_dir}/libwkhtmltox.so.#{version}")
+    end
+  end
+
+  context 'with distribution specific packages' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['wkhtmltopdf']['version'] = version
+      end.converge(described_recipe)
+    end
+
+    let(:cache_dir) { Chef::Config[:file_cache_path] }
+    let(:version) { '0.12.1' }
+    let(:archive) { "wkhtmltox-#{version}_#{platform}-#{architecture}.#{suffix}" }
+    let(:download_dest) { File.join(cache_dir, archive) }
+
+    context 'for ubuntu' do
+      let(:platform) { 'linux-precise' }
+      let(:architecture) { 'amd64' }
+      let(:suffix) { 'deb' }
+
+      it { expect(chef_run).to create_remote_file_if_missing(download_dest) }
+
+      it do
+        expect(chef_run).to install_dpkg_package('wkhtmltox')
+          .with_source(download_dest)
+      end
+    end
+
+    context 'for centos' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5') do |node|
+          node.set['wkhtmltopdf']['version'] = version
+        end.converge(described_recipe)
+      end
+
+      let(:platform) { 'linux-centos6' }
+      let(:architecture) { 'amd64' }
+      let(:suffix) { 'rpm' }
+
+      it { expect(chef_run).to create_remote_file_if_missing(download_dest) }
+
+      it do
+        expect(chef_run).to install_rpm_package('wkhtmltox')
+          .with_source(download_dest)
+      end
+    end
+
+    context 'for freebsd' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'freebsd', version: '9.2') do |node|
+          node.set['wkhtmltopdf']['version'] = version
+        end.converge(described_recipe)
+      end
+
+      it do
+        expect(chef_run).to install_package('wkhtmltopdf')
+          .with_version(version)
+      end
     end
   end
 end

--- a/spec/binary_spec.rb
+++ b/spec/binary_spec.rb
@@ -11,6 +11,7 @@ describe 'wkhtmltopdf::binary' do
     let(:suffix) { 'tar.xz' }
 
     let(:lib_dir) { '/usr/local/lib' }
+    let(:bin_dir) { '/usr/local/bin' }
     let(:home_dir) { '/usr/local/wkhtmltopdf' }
 
     cached(:chef_run) do
@@ -24,6 +25,15 @@ describe 'wkhtmltopdf::binary' do
       expect(chef_run).to install_ark('wkhtmltopdf')
         .with_url(mirror_url)
         .with_version(version)
+    end
+
+    it do
+      expect(chef_run).to create_link("#{bin_dir}/wkhtmltopdf")
+        .with_to("#{home_dir}/bin/wkhtmltopdf")
+    end
+    it do
+      expect(chef_run).to create_link("#{bin_dir}/wkhtmltoimage")
+        .with_to("#{home_dir}/bin/wkhtmltoimage")
     end
 
     it do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -30,9 +30,13 @@ describe 'wkhtmltopdf::default' do
     it { expect(chef_run).to include_recipe("wkhtmltopdf::#{install_method}") }
 
     jpeg_package = 'libjpeg'
+    archive_packages = %w(xz)
     dependency_packages = %W(fontconfig freetype libpng zlib #{jpeg_package} openssl libX11 libXext libXrender libstdc++ glibc)
     dependency_packages.each do |pkg|
       it { expect(chef_run).to install_package(pkg) }
+    end
+    archive_packages.each do |pkg|
+      it { expcet(chef_run).to install_package(pkg) }
     end
   end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,7 +1,58 @@
 require 'spec_helper'
 
 describe 'wkhtmltopdf::default' do
-  let(:chef_run) do
-    ChefSpec::Runner.new.converge(described_recipe)
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new.converge(described_recipe)
+  end
+
+  let(:install_method) { 'binary' }
+
+  context 'for ubuntu' do
+    it { expect(chef_run).to include_recipe('apt') }
+    it { expect(chef_run).to_not include_recipe('freebsd::pkgng') }
+    it { expect(chef_run).to include_recipe("wkhtmltopdf::#{install_method}") }
+
+    jpeg_package = 'libjpeg8'
+    dependency_packages = %W(fontconfig libfontconfig1 libfreetype6 libpng12-0 zlib1g #{jpeg_package} libssl1.0.0 libx11-6 libxext6 libxrender1 libstdc++6 libc6)
+    dependency_packages.each do |pkg|
+      it { expect(chef_run).to install_package(pkg) }
+    end
+  end
+
+  context 'for centos' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5')
+                          .converge(described_recipe)
+    end
+
+    it { expect(chef_run).to_not include_recipe('apt') }
+    it { expect(chef_run).to_not include_recipe('freebsd::pkgng') }
+    it { expect(chef_run).to include_recipe("wkhtmltopdf::#{install_method}") }
+
+    jpeg_package = 'libjpeg'
+    dependency_packages = %W(fontconfig freetype libpng zlib #{jpeg_package} openssl libX11 libXext libXrender libstdc++ glibc)
+    dependency_packages.each do |pkg|
+      it { expect(chef_run).to install_package(pkg) }
+    end
+  end
+
+  context 'for freebsd' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'freebsd', version: '9.2')
+                          .converge(described_recipe)
+    end
+
+    before do
+      stub_command('pkg -N').and_return(true)
+    end
+
+    it { expect(chef_run).to_not include_recipe('apt') }
+    it { expect(chef_run).to include_recipe('freebsd::pkgng') }
+    it { expect(chef_run).to include_recipe("wkhtmltopdf::#{install_method}") }
+
+    dependency_packages = %w(fontconfig freetype2 jpeg png libiconv libX11 libXext libXrender)
+    dependency_packages.each do |pkg|
+      it { expect(chef_run).to install_package(pkg) }
+    end
   end
 end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -15,7 +15,7 @@ describe 'wkhtmltopdf::source' do
   end
 
   let(:cache_dir) { '/test/cache' }
-  let(:version) { '0.12.1' }
+  let(:version) { '0.12.4' }
   let(:archive) { "wkhtmltox-#{version}.tar.bz2" }
   let(:download_dest) { File.join(cache_dir, archive) }
   let(:install_dir) { '/test/bin' }

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -89,5 +89,9 @@ describe 'wkhtmltopdf::source' do
       expect(chef_run).to create_link("#{lib_dir}/libwkhtmltox.so.0")
         .with_to("#{lib_dir}/libwkhtmltox.so.#{version}")
     end
+    it do
+      expect(chef_run).to create_link("#{lib_dir}/libwkhtmltox.so")
+        .with_to("#{lib_dir}/libwkhtmltox.so.#{version}")
+    end
   end
 end

--- a/test/integration/default/serverspec/localhost/binary_spec.rb
+++ b/test/integration/default/serverspec/localhost/binary_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe command('which wkhtmltoimage') do
+  its(:exit_status) { should eq(0) }
+end
+
+describe command('which wkhtmltopdf') do
+  its(:exit_status) { should eq(0) }
+end

--- a/test/integration/default/serverspec/localhost/lib_spec.rb
+++ b/test/integration/default/serverspec/localhost/lib_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+case os[:family]
+when 'debian', 'ubuntu', 'rhel', 'fedora'
+  describe 'libraries' do
+    lib_dir = '/usr/local/lib'
+    version = '0.12.4'
+
+    describe file("#{lib_dir}/libwkhtmltox.so.#{version}") do
+      it { should be_file }
+    end
+
+    describe file("#{lib_dir}/libwkhtmltox.so.0.12") do
+      it { should be_symlink }
+      it { should be_linked_to "#{lib_dir}/libwkhtmltox.so.#{version}" }
+    end
+
+    describe file("#{lib_dir}/libwkhtmltox.so.0") do
+      it { should be_symlink }
+      it { should be_linked_to "#{lib_dir}/libwkhtmltox.so.#{version}" }
+    end
+
+    describe file("#{lib_dir}/libwkhtmltox.so") do
+      it { should be_symlink }
+      it { should be_linked_to "#{lib_dir}/libwkhtmltox.so.#{version}" }
+    end
+  end
+end

--- a/test/integration/default/serverspec/localhost/package_spec.rb
+++ b/test/integration/default/serverspec/localhost/package_spec.rb
@@ -1,18 +1,17 @@
 require 'spec_helper'
 
-case os[:family]
-when 'freebsd'
-  describe package('wkhtmltopdf'), if: os[:release].to_f >= 10.0 do
-    it { should be_installed.with_version('0.12.1') }
-  end
+describe 'package' do
+  version = '0.12.4'
 
-  describe command('pkg query %v wkhtmltopdf'), if: os[:release].to_f < 10.0 do
-    its(:stdout) { should match(/\b0\.12\.1(?:_.*)?\b/) }
-    its(:exit_status) { should eq(0) }
-  end
+  case os[:family]
+  when 'freebsd'
+    describe package('wkhtmltopdf'), if: os[:release].to_f >= 10.0 do
+      it { should be_installed.with_version(version) }
+    end
 
-else
-  describe package('wkhtmltox'), unless: os[:family] == 'freebsd' do
-    it { should be_installed.with_version('0.12.1') }
+    describe command('pkg query %v wkhtmltopdf'), if: os[:release].to_f < 10.0 do
+      its(:stdout) { should match(/\b#{Regexp.escape(version)}(?:_.*)?\b/) }
+      its(:exit_status) { should eq(0) }
+    end
   end
 end

--- a/test/integration/source/serverspec/localhost/lib_spec.rb
+++ b/test/integration/source/serverspec/localhost/lib_spec.rb
@@ -1,19 +1,24 @@
 require 'spec_helper'
 
 describe 'libraries' do
-  let(:lib_dir) { '/usr/local/lib' }
-  let(:version) { '0.12.1' }
+  lib_dir = '/usr/local/lib'
+  version = '0.12.4'
 
-  describe file('/usr/local/lib/libwkhtmltox.so.0.12.1') do
+  describe file("#{lib_dir}/libwkhtmltox.so.#{version}") do
     it { should be_file }
   end
 
-  describe file('/usr/local/lib/libwkhtmltox.so.0.12') do
+  describe file("#{lib_dir}/libwkhtmltox.so.0.12") do
     it { should be_symlink }
     it { should be_linked_to "#{lib_dir}/libwkhtmltox.so.#{version}" }
   end
 
-  describe file('/usr/local/lib/libwkhtmltox.so.0') do
+  describe file("#{lib_dir}/libwkhtmltox.so.0") do
+    it { should be_symlink }
+    it { should be_linked_to "#{lib_dir}/libwkhtmltox.so.#{version}" }
+  end
+
+  describe file("#{lib_dir}/libwkhtmltox.so") do
     it { should be_symlink }
     it { should be_linked_to "#{lib_dir}/libwkhtmltox.so.#{version}" }
   end


### PR DESCRIPTION
* Package update to 0.12.4 (with >= 0.12.3 using linux-generic package)
* Update download URL to github releases
* Pin Chef to 11.16.4 for development (can test support for Chef 12 when needed)